### PR TITLE
allow multiple heads per group

### DIFF
--- a/components/people/mcmurtryaffinitygroups/mcmurtryaffinitygroups.css
+++ b/components/people/mcmurtryaffinitygroups/mcmurtryaffinitygroups.css
@@ -1,4 +1,12 @@
 .mcmurtry-affinity-groups-page {
-    padding-top: 10%;
-    margin-bottom: 5%;
+  padding-top: 10%;
+  margin-bottom: 5%;
+}
+
+.affinity-group-title {
+  font-size: 2em;
+  text-align: center;
+  font-weight: normal;
+  padding: 8px;
+  color: #515768;
 }

--- a/components/people/mcmurtryaffinitygroups/mcmurtryaffinitygroups.js
+++ b/components/people/mcmurtryaffinitygroups/mcmurtryaffinitygroups.js
@@ -1,22 +1,50 @@
-import React from 'react';
-import { Box, Flex } from 'rebass';
-import Title from '../../general/title';
-import Cards from '../../general/contactcards';
-import './mcmurtryaffinitygroups.css';
-import { heads } from './mcmurtryaffinitygroups.json';
+import React from "react";
+import { Box } from "rebass";
+import Title from "../../general/title";
+import ContactCards from "../../general/contactcards";
+import "./mcmurtryaffinitygroups.css";
+import { affinity_groups } from "./mcmurtryaffinitygroups.json";
 
 export default class McMurtryAffinityGroups extends React.Component {
-    render() {
-        return (
-            <div className='mcmurtry-affinity-groups-page'>
-                <Title width={400} title="McMurtry Affinity Groups" />
-                <Box width={[0.8, 0.5]} ml='auto' mr='auto'>
-                    <p>Affinity Groups at McMurtry, as extensions of the Diversity Council, aim to foster a sense of community among certain student populations including LGBTQ+, Black, Latinx, Jewish, and First-Gen/Low Income. These groups will be hosting movie nights, game nights, and other events throughout the semester in order to support and encourage connections in these groups. If you identify with one or more of these groups, we highly encourage you to join the group chats, meet new Murts and participate in any upcoming events!</p>
-                    <p>Each Affinity group has a designated liaison who acts as a bridge between the group and the Diversity Council. These are some really cool Murts who will be hosting events and activities for you all to enjoy. If you have any questions about a specific group, please feel free to reach out to the associated liaison or any member in the Diversity Council.</p>
-                    <p>If you are interested in joining one of the affinity groups, please reach out to the affinity group heads listed below</p>
-                </Box>
-                <Cards content={heads} height={180} width={260} />
-            </div>
-        )
-    }
+  render() {
+    return (
+      <div className="mcmurtry-affinity-groups-page">
+        <Title width={400} title="McMurtry Affinity Groups" />
+        <Box width={[0.8, 0.5]} ml="auto" mr="auto">
+          <p>
+            Affinity Groups at McMurtry, as extensions of the Diversity Council,
+            aim to foster a sense of community among certain student populations
+            including LGBTQ+, Black, Latinx, Jewish, and First-Gen/Low Income.
+            These groups will be hosting movie nights, game nights, and other
+            events throughout the semester in order to support and encourage
+            connections in these groups. If you identify with one or more of
+            these groups, we highly encourage you to join the group chats, meet
+            new Murts and participate in any upcoming events!
+          </p>
+          <p>
+            Each Affinity group has a designated liaison who acts as a bridge
+            between the group and the Diversity Council. These are some really
+            cool Murts who will be hosting events and activities for you all to
+            enjoy. If you have any questions about a specific group, please feel
+            free to reach out to the associated liaison or any member in the
+            Diversity Council.
+          </p>
+          <p>
+            If you are interested in joining one of the affinity groups, please
+            reach out to the affinity group heads listed below
+          </p>
+        </Box>
+        {affinity_groups.map((group) => {
+          return (
+            <>
+              <Box width={320} ml="auto" mr="auto">
+                <h1 className="affinity-group-title">{group.title}</h1>
+              </Box>
+              <ContactCards content={group.heads} width={280} height={180} />
+            </>
+          );
+        })}
+      </div>
+    );
+  }
 }

--- a/components/people/mcmurtryaffinitygroups/mcmurtryaffinitygroups.json
+++ b/components/people/mcmurtryaffinitygroups/mcmurtryaffinitygroups.json
@@ -1,29 +1,49 @@
 {
-    "heads": [
+  "affinity_groups": [
+    {
+      "title": "LGBTQ+",
+      "heads": [
         {
-            "position": "LGBTQ+",
-            "name": "Hannah Boyd",
-            "email": "hrb3@rice.edu"
-        },
-        {
-            "position": "Latinx",
-            "name": "Angelica Torres",
-            "email": "alt7@rice.edu"
-        },
-        {
-            "position": "First Gen / Low Income",
-            "name": "Jazmine Castillo",
-            "email": "jdc12@rice.edu"
-        },
-        {
-            "position": "Black",
-            "name": "Catelin Davis",
-            "email": "cnd3@rice.edu"
-        },
-        {
-            "position": "Jewish",
-            "name": "Alyson Resnick",
-            "email": "amr21@rice.edu"
+          "name": "Hannah Boyd",
+          "email": "hrb3@rice.edu"
         }
-    ]
+      ]
+    },
+    {
+      "title": "Latinx",
+      "heads": [
+        {
+          "name": "Angelica Torres",
+          "email": "alt7@rice.edu"
+        }
+      ]
+    },
+    {
+      "title": "First Gen / Low Income",
+      "heads": [
+        {
+          "name": "Jazmine Castillo",
+          "email": "jdc12@rice.edu"
+        }
+      ]
+    },
+    {
+      "title": "Black",
+      "heads": [
+        {
+          "name": "Catelin Davis",
+          "email": "cnd3@rice.edu"
+        }
+      ]
+    },
+    {
+      "title": "Jewish",
+      "heads": [
+        {
+          "name": "Alyson Resnick",
+          "email": "amr21@rice.edu"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Addresses the following task

> In the Affinity Groups page, add a way to space out the different affinity group heads from each other since most of them have more than 1 head now
> Maybe adding in titles of each AG and allowing the contact cards to go underneath each title, like the layouts of the Academic Fellows or PAAs pages
> This would also mean that we would remove the positions of all the contact cards
> Don’t worry about listing all the affinity groups, as long as the structure is there in the .json file, Adeel can update it with the right groups and people

